### PR TITLE
feat: localstorage based auth

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,8 @@ async function bootstrap() {
         callback(new Error('Not allowed by CORS'));
       }
     },
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Refresh-Token'],
+    exposedHeaders: ['x-access-token', 'x-refresh-token'],
     methods: 'GET, HEAD, PUT, PATCH, POST, DELETE',
     preflightContinue: false,
     optionsSuccessStatus: 204,

--- a/src/shared/auth/platform/auth.controller.ts
+++ b/src/shared/auth/platform/auth.controller.ts
@@ -16,7 +16,6 @@ import { ResponseUtil } from '@/shared/utils/response.util';
 import { CustomHttpException } from '@/shared/exceptions/custom-http-exception';
 import { ResendOtpDto } from './dto/resend-otp.dto';
 import { RegisterValidation } from './dto/register.validation';
-import setResponseCookies from './utils/set-response-cookies';
 import { AuthGuard } from './guards/auth.guard';
 import { UserTypes } from '@/shared/enums/user-types.enum';
 import {
@@ -36,7 +35,7 @@ export class PlatformAuthController {
   @Public()
   @Post('login')
   @HttpCode(HttpStatus.OK)
-  async companyLogin(@Body() loginDto: LoginDto, @Res() res: Response) {
+  async companyLogin(@Body() loginDto: LoginDto) {
     try {
       const payload = await this.authService.validateLogin(
         loginDto.email,
@@ -44,8 +43,7 @@ export class PlatformAuthController {
         loginDto.userType,
       );
 
-      setResponseCookies(res, payload);
-      return ResponseUtil.success('Logged in successfully');
+      return ResponseUtil.success(payload, 'Logged in successfully');
     } catch (err) {
       throw new CustomHttpException(
         err?.message,
@@ -57,12 +55,11 @@ export class PlatformAuthController {
 
   @Public()
   @Post('/google')
-  async signInWithGoogle(@Body() body: SignInWithGoogle, @Res() res: Response) {
+  async signInWithGoogle(@Body() body: SignInWithGoogle) {
     try {
       const result = await this.authService.signInWithGoogle(body);
-      setResponseCookies(res, result, { secure: true, sameSite: 'none' });
       return ResponseUtil.success(
-        null,
+        result,
         'Logged in successfully',
         HttpStatus.OK,
       );
@@ -79,13 +76,11 @@ export class PlatformAuthController {
   @Post('/linkedin')
   async signInWithLinkedIn(
     @Body() body: SignInWithLinkedInDto,
-    @Res() res: Response,
   ) {
     try {
       const result = await this.authService.signinWithLinkedIn(body);
-      setResponseCookies(res, result, { secure: true, sameSite: 'none' });
       return ResponseUtil.success(
-        null,
+        result,
         'Logged in successfully',
         HttpStatus.OK,
       );
@@ -124,7 +119,6 @@ export class PlatformAuthController {
   @Public()
   async companyRegisterVerify(
     @Body() verifyOtp: VerifyDto,
-    @Res() res: Response,
   ) {
     try {
       const payload = await this.authService.verify(
@@ -133,8 +127,7 @@ export class PlatformAuthController {
         verifyOtp.userType,
       );
 
-      setResponseCookies(res, payload);
-      return ResponseUtil.success('Otp verified successfully');
+      return ResponseUtil.success(payload, 'Otp verified successfully');
     } catch (err) {
       throw new CustomHttpException(
         err?.message,

--- a/src/shared/auth/platform/guards/auth.guard.ts
+++ b/src/shared/auth/platform/guards/auth.guard.ts
@@ -11,8 +11,8 @@ import { PostgresPrismaService } from '@/config/prisma/postgres.services';
 import { PinoLogger } from 'nestjs-pino';
 import { IS_PUBLIC_KEY } from '@/shared/decorators/isPublic.decorator';
 import { UserTypes } from '@/shared/enums/user-types.enum';
-import setResponseCookies from '../utils/set-response-cookies';
 import { JWTService } from '../../miscs/jwt';
+import setResponseAuthHeaders from '../utils/set-response-auth-headers';
 
 /**
  * If type is not provided, both user and company will be accepted
@@ -43,8 +43,7 @@ export function AuthGuard(type?: UserTypes) {
 
       const request = context.switchToHttp().getRequest<Request>();
       const response = context.switchToHttp().getResponse<Response>();
-      const { accessToken, refreshToken } =
-        this.extractTokensFromCookies(request);
+      const { accessToken, refreshToken } = this.extractTokens(request);
 
       let payload;
       try {
@@ -106,7 +105,7 @@ export function AuthGuard(type?: UserTypes) {
             userId: refreshPayload.userId,
             type: refreshPayload.type,
           });
-          setResponseCookies(response, newTokens);
+          setResponseAuthHeaders(response, newTokens);
 
           request[this.type] = record;
           return true;
@@ -120,12 +119,28 @@ export function AuthGuard(type?: UserTypes) {
       }
     }
 
-    extractTokensFromCookies(request: Request): {
+    extractTokens(request: Request): {
       accessToken: string;
       refreshToken: string;
     } {
-      const accessToken = request.cookies.access_token as string;
-      const refreshToken = request.cookies.refresh_token as string;
+      const authorizationHeader = request.headers.authorization;
+      const refreshTokenHeader = request.headers['x-refresh-token'];
+
+      const bearerToken = Array.isArray(authorizationHeader)
+        ? authorizationHeader[0]
+        : authorizationHeader;
+      const headerAccessToken = bearerToken?.startsWith('Bearer ')
+        ? bearerToken.slice(7)
+        : undefined;
+      const headerRefreshToken = Array.isArray(refreshTokenHeader)
+        ? refreshTokenHeader[0]
+        : refreshTokenHeader;
+
+      const accessToken =
+        headerAccessToken || (request.cookies.access_token as string);
+      const refreshToken =
+        headerRefreshToken || (request.cookies.refresh_token as string);
+
       if (!accessToken || !refreshToken) {
         this.logger.error('Access token or refresh token is missing');
         throw new UnauthorizedException('Invalid token');

--- a/src/shared/auth/platform/utils/set-response-auth-headers.ts
+++ b/src/shared/auth/platform/utils/set-response-auth-headers.ts
@@ -1,0 +1,12 @@
+import { Response } from 'express';
+
+export default function setResponseAuthHeaders(
+  res: Response,
+  payload: {
+    refresh_token: string;
+    access_token: string;
+  },
+): void {
+  res.setHeader('x-access-token', payload.access_token);
+  res.setHeader('x-refresh-token', payload.refresh_token);
+}

--- a/src/websocket/websocket.gateway.ts
+++ b/src/websocket/websocket.gateway.ts
@@ -36,8 +36,27 @@ export class WebsocketGateway
       // Try to get token from multiple sources
       let token: string;
 
+      const authToken =
+        typeof client.handshake.auth?.token === 'string'
+          ? client.handshake.auth.token
+          : undefined;
+      if (authToken) {
+        token = authToken;
+      }
+
+      if (!token) {
+        const authorizationHeader = client.handshake.headers.authorization;
+        const bearerToken = Array.isArray(authorizationHeader)
+          ? authorizationHeader[0]
+          : authorizationHeader;
+
+        if (bearerToken?.startsWith('Bearer ')) {
+          token = bearerToken.slice(7);
+        }
+      }
+
       const cookies = client.handshake.headers.cookie;
-      if (cookies) {
+      if (!token && cookies) {
         const cookiesArray = cookies.split(';').map((cookie) => cookie.trim());
         const tokenCookie = cookiesArray.find((c) =>
           c.startsWith('access_token='),


### PR DESCRIPTION
## Summary
- stop relying on auth cookies for platform login and verification responses
- accept bearer access tokens plus refresh headers in the platform auth guard
- expose refreshed auth tokens via response headers for the frontend client

## Testing
- backend-wide tsc remains blocked by existing Prisma/typegen issues unrelated to this change